### PR TITLE
Fix check diff step

### DIFF
--- a/.github/workflows/generate_c2a_core_reference.yml
+++ b/.github/workflows/generate_c2a_core_reference.yml
@@ -79,6 +79,7 @@ jobs:
         id: diff
         working-directory: ./docs/c2a-core
         run: |
+          git add .
           if ! git diff --exit-code --cached; then
             echo "diff"
             echo "::set-output name=update::true"
@@ -108,7 +109,6 @@ jobs:
           git branch -a
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
           git commit -am "update doxygen: C2A Core"
           git push origin
           echo "New reference is deployed!"


### PR DESCRIPTION
## 概要
Fix #12 

## Issue
- #12 

## 詳細
`git diff --exit-code --cached`前に何かしらstageされてないとダメだったのでその前に`git add`するようにした

## 検証結果
`workflow_dispatch`でデプロイが走ればよし

